### PR TITLE
Bump version to 2.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            1.x
 
   release:
     runs-on: ubuntu-latest

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,5 +4,5 @@ appName = com.enonic.app.proxydebug
 appDisplayName = Proxy Debug
 vendorName = Enonic AS
 vendorUrl = https://enonic.com
-version=1.0.1-SNAPSHOT
+version=2.0.0-SNAPSHOT
 xpVersion = 8.0.0-B4


### PR DESCRIPTION
## Summary

- Bump master `version` from `1.0.1-SNAPSHOT` to `2.0.0-SNAPSHOT` to start the XP 8 line.
- Add `releaseBranch` block to `.github/workflows/enonic-gradle.yml` listing both `master` and `1.x` so pushes to either are recognized as release-branch builds by `enonic/release-tools/build-and-publish`.

The companion `1.x` maintenance branch was forked from commit `28c166b` (the post-`v1.0.0` "Updated to next SNAPSHOT version" commit) and continues on `1.0.1-SNAPSHOT` for XP 7. A separate PR against `1.x` adds the matching `releaseBranch` config there.

Reference pattern: [enonic/app-booster](https://github.com/enonic/app-booster) `master` vs `1.x`.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, master CI run succeeds with the new `releaseBranch` config

🤖 Generated with [Claude Code](https://claude.com/claude-code)