### PR TITLE
Bump lib-http-client/lib-mustache to XP 8 SNAPSHOTs #35

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-http-client = "3.2.2"
-mustache    = "2.1.1"
+http-client = "4.0.0-SNAPSHOT"
+mustache    = "3.0.0-SNAPSHOT"
 
 [libraries]
 lib-http-client = { module = "com.enonic.lib:lib-http-client", version.ref = "http-client" }


### PR DESCRIPTION
Closes #35

## Summary

- `lib-http-client` 3.2.2 → 4.0.0-SNAPSHOT
- `lib-mustache` 2.1.1 → 3.0.0-SNAPSHOT

Aligns the bundled JavaScript libraries with XP 8. SNAPSHOTs resolve from `repo.enonic.com/dev`, which is already wired via `xp.enonicRepo('dev')` in `build.gradle`.

## E2E result on XP 8.0.0-B4 with this PR

`PASS`. Bundle reaches ACTIVE; webapp and admin-tool endpoints respond with the expected JSON/HTML payloads:

```
00:39:49.124 INFO  c.e.x.c.i.a.ApplicationRegistryImpl - Started application com.enonic.app.proxydebug bundle 117
```

```
$ curl -b cookies.txt -H 'Accept: application/json' http://localhost:8080/webapp/com.enonic.app.proxydebug/
HTTP 200 — Content-Type: text/json
{"request":{...},"node":{"clusterName":"mycluster","nodeIsMaster":true,...},"xp":{"version":"8.0.0-B4","hash":"a0f053aa..."}}
```

Full E2E details in #35.

## Test plan

- [x] `./gradlew build` against the new versions
- [x] Bundle reaches ACTIVE on XP 8.0.0-B4
- [x] `/webapp/com.enonic.app.proxydebug/` returns 200 JSON (Accept: application/json) for an authenticated admin
- [x] `/webapp/com.enonic.app.proxydebug/` returns 200 mustache-rendered HTML (Accept: text/html) for an authenticated admin
- [x] `/admin/com.enonic.app.proxydebug/main` returns 200 for an authenticated admin

🤖 Generated with [Claude Code](https://claude.com/claude-code)