### PR TITLE
GraalJS Compatibility #41

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,6 @@ dependencies {
     testImplementation platform( 'org.junit:junit-bom:6.1.2' )
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    testRuntimeOnly 'org.graalvm.polyglot:js:25.0.3'
 }
 
 repositories {
@@ -29,14 +28,6 @@ test {
     useJUnitPlatform()
 }
 
-def testGraalJs = tasks.register('testGraalJs', Test) {
-    group = 'verification'
-    description = 'Runs tests with the GraalJS script engine.'
-    useJUnitPlatform()
-    testClassesDirs = sourceSets.test.output.classesDirs
-    classpath = sourceSets.test.runtimeClasspath
-    systemProperty 'xp.script-engine', 'GraalJS'
-    shouldRunAfter test
+xp {
+    scriptEngines = ['Nashorn', 'GraalJS']
 }
-
-check.dependsOn testGraalJs

--- a/build.gradle
+++ b/build.gradle
@@ -8,8 +8,15 @@ dependencies {
     implementation xplibs.api.core
     implementation xplibs.api.portal
     include xplibs.auth
+    include xplibs.task
     include libs.lib.http.client
     include libs.lib.mustache
+
+    testImplementation "com.enonic.xp:testing:${xpVersion}"
+    testImplementation platform( 'org.junit:junit-bom:6.1.2' )
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testRuntimeOnly 'org.graalvm.polyglot:js:25.0.3'
 }
 
 repositories {
@@ -17,3 +24,19 @@ repositories {
     mavenCentral()
     xp.enonicRepo( 'dev' )
 }
+
+test {
+    useJUnitPlatform()
+}
+
+def testGraalJs = tasks.register('testGraalJs', Test) {
+    group = 'verification'
+    description = 'Runs tests with the GraalJS script engine.'
+    useJUnitPlatform()
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+    systemProperty 'xp.script-engine', 'GraalJS'
+    shouldRunAfter test
+}
+
+check.dependsOn testGraalJs

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ appDisplayName = Proxy Debug
 vendorName = Enonic AS
 vendorUrl = https://enonic.com
 version=2.0.0-SNAPSHOT
-xpVersion = 8.0.2
+xpVersion = 8.1.0-SNAPSHOT

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.enonic.xp.settings' version '4.1.0'
+    id 'com.enonic.xp.settings' version '4.2.0'
 }
 
 rootProject.name = projectName

--- a/src/main/resources/lib/proxy.js
+++ b/src/main/resources/lib/proxy.js
@@ -53,7 +53,7 @@ function handle200(req) {
 
     if (req.params['stall']) {
         try {
-            java.lang.Thread.sleep(req.params['stall']);
+            require('/lib/xp/task').sleep(Number(req.params['stall']));
         } catch (e) {
             // Ignore
         }

--- a/src/main/resources/lib/util.js
+++ b/src/main/resources/lib/util.js
@@ -21,5 +21,5 @@ exports.isMember = function (key) {
 }
 
 exports.returnHtml = function (req) {
-    return req.headers['Accept'] && req.headers['Accept'].contains('text/html');
+    return req.headers['Accept'] && req.headers['Accept'].indexOf('text/html') !== -1;
 }

--- a/src/test/java/com/enonic/app/proxydebug/ProxyDebugTest.java
+++ b/src/test/java/com/enonic/app/proxydebug/ProxyDebugTest.java
@@ -1,0 +1,33 @@
+package com.enonic.app.proxydebug;
+
+import org.junit.jupiter.api.Test;
+
+import com.enonic.xp.testing.ScriptTestSupport;
+
+public class ProxyDebugTest
+    extends ScriptTestSupport
+{
+    @Test
+    public void returnHtmlTrueWhenAcceptHasTextHtml()
+    {
+        runFunction( "/lib/util-test.js", "returnHtmlTrueWhenAcceptHasTextHtml" );
+    }
+
+    @Test
+    public void returnHtmlFalseWhenAcceptLacksTextHtml()
+    {
+        runFunction( "/lib/util-test.js", "returnHtmlFalseWhenAcceptLacksTextHtml" );
+    }
+
+    @Test
+    public void stallSleepsForParsedMillis()
+    {
+        runFunction( "/lib/proxy-test.js", "stallSleepsForParsedMillis" );
+    }
+
+    @Test
+    public void noStallDoesNotSleep()
+    {
+        runFunction( "/lib/proxy-test.js", "noStallDoesNotSleep" );
+    }
+}

--- a/src/test/resources/lib/proxy-test.js
+++ b/src/test/resources/lib/proxy-test.js
@@ -1,0 +1,41 @@
+var assert = require('/lib/xp/testing');
+
+var sleptFor = null;
+
+assert.mock('/lib/util', {
+    isMember: function () {
+        return true;
+    },
+    returnHtml: function () {
+        return false;
+    }
+});
+assert.mock('/lib/http-client', {
+    request: function () {
+        return { body: 'null' };
+    }
+});
+assert.mock('/lib/mustache', {
+    render: function () {
+        return '';
+    }
+});
+assert.mock('/lib/xp/task', {
+    sleep: function (ms) {
+        sleptFor = ms;
+    }
+});
+
+var proxy = require('/lib/proxy');
+
+exports.stallSleepsForParsedMillis = function () {
+    sleptFor = null;
+    proxy.handle({ params: { stall: '250' }, headers: {} });
+    assert.assertTrue(sleptFor === 250, 'expected sleep(250), got ' + sleptFor);
+};
+
+exports.noStallDoesNotSleep = function () {
+    sleptFor = null;
+    proxy.handle({ params: {}, headers: {} });
+    assert.assertTrue(sleptFor === null, 'expected no sleep, got ' + sleptFor);
+};

--- a/src/test/resources/lib/util-test.js
+++ b/src/test/resources/lib/util-test.js
@@ -1,0 +1,20 @@
+var assert = require('/lib/xp/testing');
+
+assert.mock('/lib/xp/auth', {
+    getUser: function () {
+        return null;
+    },
+    getMemberships: function () {
+        return [];
+    }
+});
+
+var util = require('/lib/util');
+
+exports.returnHtmlTrueWhenAcceptHasTextHtml = function () {
+    assert.assertTrue(util.returnHtml({ headers: { Accept: 'text/html,application/xhtml+xml' } }));
+};
+
+exports.returnHtmlFalseWhenAcceptLacksTextHtml = function () {
+    assert.assertFalse(util.returnHtml({ headers: { Accept: 'application/json' } }));
+};


### PR DESCRIPTION
Fixes #41

Prepares the app for the Nashorn→GraalJS migration by removing the two Nashorn-only constructs the issue identified, and adds a dual-engine test harness so both engines are exercised.

## Changes

**`lib/util.js:24`** — `req.headers['Accept'].contains('text/html')`
`String.contains()` is a *Java* method; it only worked because Nashorn hands header values in as `java.lang.String`. Under GraalJS those arrive as JS primitives with no `.contains()`.

I used **`indexOf('text/html') !== -1`** rather than the issue's suggested `.includes()`. XP's Nashorn is ES5.1 and has **no `String.prototype.includes`** — `.includes()` makes the Nashorn `test` task fail with `TypeError: ...includes is not a function` (verified locally). `indexOf` is the standard-JS equivalent that is present on both engines (and on the production Java-String path under Nashorn), so `test` and `testGraalJs` both stay green.

**`lib/proxy.js:56`** — `java.lang.Thread.sleep(req.params['stall'])`
The `java.*` package globals are Nashorn-only. Replaced with the platform API `require('/lib/xp/task').sleep(...)`. The `stall` param is a string, so it's wrapped in `Number(...)` (GraalJS host interop won't coerce a string into the bean's `Double` setter).

**Build / test setup** (mirrors `xp/gradle/js-tests.gradle`)
- `gradle.properties`: `xpVersion` → `8.1.0-SNAPSHOT`
- `build.gradle`: `testRuntimeOnly 'org.graalvm.polyglot:js:25.0.3'`, a `testGraalJs` task wired into `check`, JUnit test deps + `com.enonic.xp:testing`, and `include xplibs.task` for the new `/lib/xp/task` require.
- New `ScriptTestSupport` tests (`ProxyDebugTest` + `util-test.js` / `proxy-test.js`) covering both fixes.

## Verification

Built the platform GraalJS branch (`enonic/xp` @ `claude/graaljs-support-limitations-pzu6z8`) to `~/.m2` and ran locally against it:

```
./gradlew test testGraalJs
# :test (Nashorn)   4/4 green
# :testGraalJs      4/4 green
```

## Draft note

Marked **draft** as part of the migration process. The tests use `ScriptTestSupport` (per-`@Test` `runFunction`), which is *not* affected by the executor-teardown bug fixed in **enonic/xp#12198**, so CI's `testGraalJs` is expected to pass against the currently-published `8.1.0-SNAPSHOT`. If the snapshot on `repo.enonic.com/dev` lags the GraalJS platform work, `testGraalJs` will stay red until enonic/xp#12198 merges and a fresh `8.1.0-SNAPSHOT` publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)